### PR TITLE
Fix Jetbrains IDE unable to load project

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -6,3 +6,4 @@
 # Datasource local storage ignored files
 /dataSources/
 /dataSources.local.xml
+discord.xml

--- a/.idea/SimpleTranslator.iml
+++ b/.idea/SimpleTranslator.iml
@@ -3,9 +3,8 @@
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
-      <excludeFolder url="file://$MODULE_DIR$/models" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.13 virtualenv at C:\Users\User\PycharmProjects\SimpleTranslator\.venv" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.13 (SimpleTranslator)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,5 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <settings>
+    <option name="PROJECT_PROFILE" value="Default" />
     <option name="USE_PROJECT_PROFILE" value="false" />
     <version value="1.0" />
   </settings>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.13 (SimpleTranslator)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/JupyterProject.iml" filepath="$PROJECT_DIR$/.idea/JupyterProject.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/SimpleTranslator.iml" filepath="$PROJECT_DIR$/.idea/SimpleTranslator.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="" vcs="Git" />
   </component>
 </project>


### PR DESCRIPTION
Due to a misconfigured .idea configuration file, the project couldn't be loaded and requires manual intervention. 

![image](https://github.com/user-attachments/assets/063a61ea-d792-4f02-bdaa-b77f6c2a9ae9)

On further inspection, it turns out the problem was an invalid file reference in `.idea/modules.xml` referencing the file `JupyterProject.iml` which was renamed to `SimpleTranslator.iml`.